### PR TITLE
.ToLower() -> .ToLowerInvariant()

### DIFF
--- a/src/KeyChain.Net.XamarinAndroid/KeyChainHelper.cs
+++ b/src/KeyChain.Net.XamarinAndroid/KeyChainHelper.cs
@@ -76,12 +76,12 @@ namespace KeyChain.Net.XamarinAndroid
 		/// <param name="keyName">Keyname/username.</param>
 		public string GetKey (string keyName)
 		{
-			var wantedAlias = MakeAlias(keyName, _serviceId).ToLower();
+			var wantedAlias = MakeAlias(keyName, _serviceId).ToLowerInvariant();
 
 			var aliases = _androidKeyStore.Aliases ();
 			while (aliases.HasMoreElements) {
 				var alias = aliases.NextElement ().ToString ();
-				if (alias.ToLower().Contains(wantedAlias)) 
+				if (alias.ToLowerInvariant().Contains(wantedAlias)) 
 				{
 					var e = _androidKeyStore.GetEntry (alias, _passwordProtection) as KeyStore.SecretKeyEntry;
 					if (e != null) 

--- a/src/KeyChain.Net.XamarinIOS/KeyChainHelper.cs
+++ b/src/KeyChain.Net.XamarinIOS/KeyChainHelper.cs
@@ -92,8 +92,8 @@ namespace KeyChain.Net.XamarinIOS
 			}
 			
 			// Querying is case sesitive - we don't want that.
-			username = username.ToLower (  );
-			serviceId = serviceId.ToLower (  );
+			username = username.ToLowerInvariant (  );
+			serviceId = serviceId.ToLowerInvariant (  );
 			
 			// Query and remove.
 			SecRecord queryRec = new SecRecord ( SecKind.GenericPassword ) { Service = serviceId, Label = serviceId, Account = username, Synchronizable = synchronizable };
@@ -128,8 +128,8 @@ namespace KeyChain.Net.XamarinIOS
 			}
 			
 			// Querying is case sesitive - we don't want that.
-			username = username.ToLower (  );
-			serviceId = serviceId.ToLower (  );
+			username = username.ToLowerInvariant (  );
+			serviceId = serviceId.ToLowerInvariant (  );
 			
 			// Don't bother updating. Delete existing record and create a new one.
 			DeletePassword ( username, serviceId, synchronizable );
@@ -173,8 +173,8 @@ namespace KeyChain.Net.XamarinIOS
 			}
 			
 			// Querying is case sesitive - we don't want that.
-			username = username.ToLower (  );
-			serviceId = serviceId.ToLower (  );
+			username = username.ToLowerInvariant (  );
+			serviceId = serviceId.ToLowerInvariant (  );
 			
 			SecStatusCode code;
 			// Query the record.


### PR DESCRIPTION
hi, I had an issue in AppDelegate on a turkish iPhone, where the key "enrolledUniqueId" was transformed to "enrolleduniqueıd" (notice the 'I') then later on in the app, toLower converted it back to "enrolledUniqueId", making the whole keychain unusable. Took me a while to figure out.
but as I'm writing this, I realize this would be a breaking change for you and probably cannot be released ...